### PR TITLE
build: replace tools/build-libs.sh with build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 zig-cache/
-zig-out*/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -42,21 +42,41 @@ pub fn build(b: *std.Build) void {
 
     const libzimalloc_step = b.step("libzimalloc", "Build the libzimalloc shared library");
 
-    const libzimalloc_version = std.SemanticVersion{ .major = 0, .minor = 0, .patch = 0 };
-    const libzimalloc = b.addSharedLibrary(.{
-        .name = "zimalloc",
-        .root_source_file = .{ .path = "src/libzimalloc.zig" },
-        .version = libzimalloc_version,
+    const libzimalloc = addLibzimalloc(b, .{
         .target = target,
         .optimize = optimize,
-        .link_libc = true,
+        .zimalloc_options = zimalloc_options,
     });
-    libzimalloc.addModule("build_options", zimalloc_options);
-    libzimalloc.force_pic = true;
 
     const libzimalloc_install = b.addInstallArtifact(libzimalloc, .{});
     b.getInstallStep().dependOn(&libzimalloc_install.step);
     libzimalloc_step.dependOn(&libzimalloc_install.step);
+
+    const libzimalloc_test_builds_step = b.step(
+        "libzimalloc-builds",
+        "Build libzimalloc with different configurations for testing",
+    );
+    for (test_configs) |config| {
+        const options = b.addOptions();
+        options.addOption(bool, "verbose_logging", config.verbose);
+        options.addOption(std.log.Level, "log_level", config.log_level);
+        options.addOption(bool, "panic_on_invalid", config.panic_on_invalid);
+        const options_module = options.createModule();
+        const compile = addLibzimalloc(b, .{
+            .target = target,
+            .optimize = config.optimize,
+            .zimalloc_options = options_module,
+        });
+
+        const install = b.addInstallArtifact(compile, .{
+            .dest_dir = .{
+                .override = .{ .custom = b.pathJoin(&.{ "test", @tagName(config.optimize) }) },
+            },
+            .dest_sub_path = config.name(b.allocator),
+            .dylib_symlinks = false,
+        });
+        libzimalloc_test_builds_step.dependOn(&install.step);
+    }
 
     const tests = b.addTest(.{
         .root_source_file = .{ .path = "src/zimalloc.zig" },
@@ -77,7 +97,11 @@ pub fn build(b: *std.Build) void {
     const standalone_test_build_step = b.step("standalone-build", "Build the standalone tests");
 
     const standalone_options = b.addOptions();
-    const standalone_pauses = b.option(bool, "pauses", "Insert pauses into standalone tests (default: false)") orelse false;
+    const standalone_pauses = b.option(
+        bool,
+        "pauses",
+        "Insert pauses into standalone tests (default: false)",
+    ) orelse false;
     standalone_options.addOption(bool, "pauses", standalone_pauses);
 
     for (standalone_tests) |test_name| {
@@ -101,6 +125,75 @@ pub fn build(b: *std.Build) void {
     }
 }
 
+const LibzimallocOptions = struct {
+    target: std.zig.CrossTarget,
+    optimize: std.builtin.Mode,
+    zimalloc_options: *std.Build.Module,
+    linkage: std.Build.Step.Compile.Linkage = .dynamic,
+    force_pic: bool = true,
+};
+
+fn addLibzimalloc(b: *std.Build, options: LibzimallocOptions) *std.Build.Step.Compile {
+    const libzimalloc_version = std.SemanticVersion{ .major = 0, .minor = 0, .patch = 0 };
+    const libzimalloc = switch (options.linkage) {
+        .dynamic => b.addSharedLibrary(.{
+            .name = "zimalloc",
+            .root_source_file = .{ .path = "src/libzimalloc.zig" },
+            .version = libzimalloc_version,
+            .target = options.target,
+            .optimize = options.optimize,
+            .link_libc = true,
+        }),
+        .static => b.addStaticLibrary(.{
+            .name = "zimalloc",
+            .root_source_file = .{ .path = "src/libzimalloc.zig" },
+            .version = libzimalloc_version,
+            .target = options.target,
+            .optimize = options.optimize,
+            .link_libc = true,
+        }),
+    };
+
+    libzimalloc.addModule("build_options", options.zimalloc_options);
+    libzimalloc.force_pic = options.force_pic;
+    return libzimalloc;
+}
+
 const standalone_tests = [_][]const u8{
     "create-destroy-loop.zig",
 };
+
+const TestBuildConfig = struct {
+    optimize: std.builtin.OptimizeMode,
+    verbose: bool,
+    log_level: std.log.Level,
+    panic_on_invalid: bool,
+
+    fn name(self: TestBuildConfig, allocator: std.mem.Allocator) []const u8 {
+        var parts: [4][]const u8 = undefined;
+        var i: usize = 0;
+        parts[i] = "libzimalloc";
+        i += 1;
+        if (self.verbose) {
+            parts[i] = "verbose";
+            i += 1;
+        }
+        if (self.log_level != .warn) {
+            parts[i] = @tagName(self.log_level);
+            i += 1;
+        }
+        if (self.panic_on_invalid) {
+            parts[i] = "panic";
+            i += 1;
+        }
+        return std.mem.join(allocator, "-", parts[0..i]) catch @panic("OOM");
+    }
+};
+
+// zig fmt: off
+const test_configs = [_]TestBuildConfig{
+    .{ .optimize = .ReleaseSafe,  .verbose = false, .log_level = .warn,  .panic_on_invalid = false },
+    .{ .optimize = .ReleaseSafe,  .verbose = true,  .log_level = .debug, .panic_on_invalid = false },
+    .{ .optimize = .ReleaseFast,  .verbose = false, .log_level = .warn,  .panic_on_invalid = false },
+};
+// zig fmt: on

--- a/tools/build-libs.sh
+++ b/tools/build-libs.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-zig build libzimalloc -Doptimize=ReleaseSafe -Dlog-level=debug -Dverbose-logging
-zig build libzimalloc -Doptimize=ReleaseSafe -p zig-out-safe
-zig build libzimalloc -Doptimize=ReleaseFast -p zig-out-fast


### PR DESCRIPTION
This adds a relatively large amount to `build.zig` in exchange for removing the need for an external script to invoke `zig build`.