### PR TITLE
Fix buffer overrun in aligned allocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
       - name: Run espresso
         run: LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" out/bench/espresso bench/espresso/largest.espresso
 
+      - name: Run rptest
+        run: LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" out/bench/rptest ${{ steps.bench-setup.outputs.procs }} 0 1 2 500 1000 100 8 16000
+
       - name: Run mleak
         run: |
           LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" out/bench/mleak 5

--- a/src/Heap.zig
+++ b/src/Heap.zig
@@ -178,9 +178,9 @@ pub fn allocate(self: *Heap, len: usize, log2_align: u8, ret_addr: usize) ?Alloc
     return null;
 }
 
-pub fn resizeInPlace(self: *Heap, buf: []u8, log2_align: u8, new_len: usize, ret_addr: usize) bool {
+pub fn canResizeInPlace(self: *Heap, buf: []u8, log2_align: u8, new_len: usize, ret_addr: usize) bool {
     log.debugVerbose(
-        "can resize: buf.ptr={*}, buf.len={d}, log2_align={d}, new_len={d}",
+        "canResizeInPlace: buf.ptr={*}, buf.len={d}, log2_align={d}, new_len={d}",
         .{ buf.ptr, buf.len, log2_align, new_len },
     );
 
@@ -274,7 +274,7 @@ fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, ret_addr: usize) ?[*]u8 {
 
 fn resize(ctx: *anyopaque, buf: []u8, log2_align: u8, new_len: usize, ret_addr: usize) bool {
     const self: *@This() = @ptrCast(@alignCast(ctx));
-    return self.resizeInPlace(buf, log2_align, new_len, ret_addr);
+    return self.canResizeInPlace(buf, log2_align, new_len, ret_addr);
 }
 
 fn free(ctx: *anyopaque, buf: []u8, log2_align: u8, ret_addr: usize) void {

--- a/src/Heap.zig
+++ b/src/Heap.zig
@@ -47,7 +47,7 @@ pub const Alloc = struct {
 pub fn allocateHuge(self: *Heap, len: usize, log2_align: u8, ret_addr: usize) ?Alloc {
     assert.withMessage(@src(), self.thread_id == std.Thread.getCurrentId(), "tried to allocate from wrong thread");
 
-    log.debug("allocate: huge allocation len={d}, log2_align={d}", .{ len, log2_align });
+    log.debug("allocateHuge: len={d}, log2_align={d}", .{ len, log2_align });
 
     self.huge_allocations.lock();
     defer self.huge_allocations.unlock();
@@ -74,7 +74,7 @@ pub fn allocateSizeClass(self: *Heap, class: usize, log2_align: u8) ?Alloc {
     assert.withMessage(@src(), class < size_class_count, "requested size class is too big");
 
     log.debugVerbose(
-        "allocate: size class={d}, log2_align={d}",
+        "allocateSizeClass: size class={d}, log2_align={d}",
         .{ class, log2_align },
     );
 

--- a/src/Page.zig
+++ b/src/Page.zig
@@ -78,6 +78,7 @@ pub fn allocSlotFast(self: *Page) ?Slot {
     const node_ptr = self.alloc_free_list.popFirst() orelse return null;
     const casted_ptr: [*]align(constants.min_slot_alignment) u8 = @ptrCast(node_ptr);
     self.used_count += 1;
+    @memset(casted_ptr[0..self.slot_size], undefined);
     return @ptrCast(casted_ptr[0..self.slot_size]);
 }
 

--- a/src/allocator.zig
+++ b/src/allocator.zig
@@ -158,6 +158,7 @@ pub fn Allocator(comptime config: Config) type {
             ret_addr: usize,
             comptime lock_held: bool,
         ) ?[*]align(constants.min_slot_alignment) u8 {
+            log.debugVerbose("allocate: len={d} log2_align={d}", .{ len, log2_align });
             if (config.memory_limit) |limit| {
                 assert.withMessage(@src(), self.stats.total_allocated_memory <= limit, "corrupt stats");
                 if (len + self.stats.total_allocated_memory > limit) {
@@ -245,6 +246,7 @@ pub fn Allocator(comptime config: Config) type {
             ret_addr: usize,
             comptime lock_held: bool,
         ) void {
+            log.debugVerbose("deallocate: buf=({*}, {d}) log2_align={d}", .{ buf.ptr, buf.len, log2_align });
             // TODO: check this is valid on windows
             // this check also covers buf.len > constants.max_slot_size_large_page
             if (std.mem.isAligned(@intFromPtr(buf.ptr), std.mem.page_size)) {

--- a/src/allocator.zig
+++ b/src/allocator.zig
@@ -398,7 +398,7 @@ pub fn Allocator(comptime config: Config) type {
                 return false;
             };
 
-            const can_resize = owning_heap.resizeInPlace(buf, log2_align, new_len, ret_addr);
+            const can_resize = owning_heap.canResizeInPlace(buf, log2_align, new_len, ret_addr);
 
             // BUG: there is a bug for memory limiting here if `buf` is a huge allocation
             //      that gets shrunk to a lower os page count (see std.heap.PageAllocator.resize)


### PR DESCRIPTION
This fixes an issue with `allocateSizeClass` performing a buffer overrun when setting the slot to `undefined` when allocating with an alignment greater than the size classes' natural alignment.

This fix allows rptest to run successfully and so adds it to the CI, taking a step towards #5.