### PR TITLE
bug fixes for realloc and resize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,12 @@ jobs:
       - name: Build benchmarks
         if: steps.cache-benchmarks.outputs.cache-hit != 'true'
         run: |
-          echo "::group::Install dos2unix"
+          echo "::group::Install dependencies"
           sudo apt-get update
           sudo apt-get install dos2unix
           echo "::endgroup::"
           echo "::group::Build"
-          ./build-bench-env.sh bench lean
+          ./build-bench-env.sh bench lean redis
           echo "::endgroup::"
 
       - name: Download libzimalloc artifact
@@ -83,9 +83,9 @@ jobs:
       - name: Setup benchmarks
         id: bench-setup
         run: |
-          echo "::group::Install ghostscript"
+          echo "::group::Install dependencies"
           sudo apt-get update
-          sudo apt-get install ghostscript
+          sudo apt-get install ghostscript ruby
           echo "::endgroup::"
           if command -v nproc > /dev/null; then
             procs=$(nproc)
@@ -98,6 +98,7 @@ jobs:
             echo "procsx2=16" >> "$GITHUB_OUTPUT"
           fi
           echo "ld_preload=${{ steps.download.outputs.download-path }}/zig-out-release-safe/lib/libzimalloc.so" >> "$GITHUB_OUTPUT"
+          echo "redis_version=$(grep -E version_redis= bench.sh | cut -d= -f2)" >> "$GITHUB_OUTPUT"
 
       - name: Run mstress
         run: LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" out/bench/mstress ${{ steps.bench-setup.outputs.procs }} 50 25
@@ -136,6 +137,34 @@ jobs:
 
       - name: Run malloc-large
         run: LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" out/bench/malloc-large
+
+      - name: Run lua
+        run: |
+          pushd extern/lua
+          LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" make
+          make clean
+          popd
+
+      - name: Run redis
+        run: |
+          redis_path=extern/redis-${{ steps.bench-setup.outputs.redis_version }}/src
+          LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" $redis_path/redis-server &
+          sleep 1s
+          $redis_path/redis-cli flushall
+          sleep 1s
+          $redis_path/redis-benchmark -r 1000000 -n 100000 -q -P 16 lpush a 1 2 3 4 5 lrange a 1 5
+          sleep 1s
+          $redis_path/redis-cli flushall
+          sleep 1s
+          $redis_path/redis-cli shutdown
+          sleep 1s
+
+      - name: Run rbstress
+        run: |
+          LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" ruby bench/rbstress/stress_mem.rb 1
+          if test "${{ steps.bench-setup.outputs.procs }}" != "1"; then
+            LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" ruby bench/rbstress/stress_mem.rb ${{ steps.bench-setup.outputs.procs }}
+          fi
 
       - name: Run espresso
         run: LD_PRELOAD="${{ steps.bench-setup.outputs.ld_preload }}" out/bench/espresso bench/espresso/largest.espresso

--- a/src/allocator.zig
+++ b/src/allocator.zig
@@ -1,45 +1,17 @@
 pub const Config = struct {
-    memory_limit: ?usize = null,
     thread_data_prealloc: usize = 128,
     thread_safe: bool = !builtin.single_threaded,
-    track_allocations: bool = false, // TODO: use this to assert usage/invariants
     safety_checks: bool = std.debug.runtime_safety,
 };
 
 pub fn Allocator(comptime config: Config) type {
     return struct {
         backing_allocator: std.mem.Allocator = std.heap.page_allocator,
-        thread_heaps: std.SegmentedList(ThreadHeapData, config.thread_data_prealloc) = .{},
+        thread_heaps: std.SegmentedList(Heap, config.thread_data_prealloc) = .{},
         thread_heaps_lock: std.Thread.RwLock = .{},
         // TODO: atomic access
-        stats: Stats = if (config.memory_limit != null) .{} else {},
 
         const Self = @This();
-
-        pub const Stats = if (config.memory_limit != null)
-            struct {
-                total_allocated_memory: usize = 0,
-            }
-        else
-            void;
-
-        const AllocData = struct {
-            size: usize,
-            is_huge: bool,
-        };
-
-        const Metadata = if (config.track_allocations)
-            struct {
-                map: std.AutoHashMapUnmanaged(usize, AllocData) = .{},
-                mutex: std.Thread.Mutex = .{},
-            }
-        else
-            void;
-
-        const ThreadHeapData = struct {
-            heap: Heap,
-            metadata: Metadata = if (config.track_allocations) .{} else {},
-        };
 
         pub fn init(backing_allocator: std.mem.Allocator) error{OutOfMemory}!Self {
             return .{
@@ -51,12 +23,8 @@ pub fn Allocator(comptime config: Config) type {
         pub fn deinit(self: *Self) void {
             self.thread_heaps_lock.lock();
             var heap_iter = self.thread_heaps.iterator(0);
-            while (heap_iter.next()) |heap_data| {
-                if (config.track_allocations) {
-                    heap_data.metadata.mutex.lock();
-                    heap_data.metadata.map.deinit(self.backing_allocator);
-                }
-                heap_data.heap.deinit();
+            while (heap_iter.next()) |heap| {
+                heap.deinit();
             }
             self.thread_heaps.deinit(self.backing_allocator);
             self.* = undefined;
@@ -64,7 +32,7 @@ pub fn Allocator(comptime config: Config) type {
 
         fn initHeapForThread(
             self: *Self,
-        ) ?*ThreadHeapData {
+        ) ?*Heap {
             const thread_id = std.Thread.getCurrentId();
             log.debug("initialising heap for thread {d}", .{thread_id});
 
@@ -74,9 +42,7 @@ pub fn Allocator(comptime config: Config) type {
 
             const new_ptr = self.thread_heaps.addOne(self.backing_allocator) catch return null;
 
-            new_ptr.* = .{
-                .heap = Heap.init(),
-            };
+            new_ptr.* = Heap.init();
 
             log.debug("heap initialised: {*}", .{new_ptr});
             return new_ptr;
@@ -87,58 +53,39 @@ pub fn Allocator(comptime config: Config) type {
             self.thread_heaps_lock.lockShared();
             defer self.thread_heaps_lock.unlockShared();
             var iter = self.thread_heaps.constIterator(0);
-            while (iter.next()) |heap_data| : (index += 1) {
-                if (&heap_data.heap == heap) return true;
+            while (iter.next()) |child_heap| : (index += 1) {
+                if (child_heap == heap) return true;
             }
             return false;
         }
 
-        pub usingnamespace if (config.track_allocations) struct {
-            pub fn getThreadData(
-                self: *Self,
-                ptr: *anyopaque,
-                comptime hold_lock: bool,
-            ) !*ThreadHeapData {
-                // TODO: check this is valid on windows
-                // this check also covers buf.len > constants.max_slot_size_large_page
+        pub fn getThreadHeap(
+            self: *Self,
+            ptr: *anyopaque,
+        ) ?*Heap {
+            // TODO: check this is valid on windows
+            // this check also covers buf.len > constants.max_slot_size_large_page
 
-                if (std.mem.isAligned(@intFromPtr(ptr), std.mem.page_size)) {
-                    self.thread_heaps_lock.lockShared();
-                    defer self.thread_heaps_lock.unlockShared();
-                    var heap_iter = self.thread_heaps.iterator(0);
-                    while (heap_iter.next()) |heap_data| {
-                        if (heap_data.heap.huge_allocations.contains(ptr)) {
-                            const metadata = &heap_data.metadata;
-
-                            metadata.mutex.lock();
-                            defer if (!hold_lock) metadata.mutex.unlock();
-
-                            const data = metadata.map.get(@intFromPtr(ptr)) orelse {
-                                @panic("large allocation metadata is missing");
-                            };
-                            assert.withMessage(@src(), data.is_huge, "metadata flag is_huge is not set");
-                            return heap_data;
-                        }
+            if (std.mem.isAligned(@intFromPtr(ptr), std.mem.page_size)) {
+                self.thread_heaps_lock.lockShared();
+                defer self.thread_heaps_lock.unlockShared();
+                var heap_iter = self.thread_heaps.iterator(0);
+                while (heap_iter.next()) |heap| {
+                    if (heap.huge_allocations.contains(ptr)) {
+                        return heap;
                     }
                 }
-
-                const segment = Segment.ofPtr(ptr);
-                const owning_heap = segment.heap;
-                const heap_data = @fieldParentPtr(ThreadHeapData, "heap", owning_heap);
-                assert.withMessage(@src(), &heap_data.heap == owning_heap, "heap metadata corrupt");
-
-                if (config.safety_checks) if (!self.ownsHeap(owning_heap)) return error.BadHeap;
-
-                if (hold_lock) heap_data.metadata.mutex.lock();
-
-                return heap_data;
             }
 
-            fn heapMetadataUnsafe(heap: *Heap) *Metadata {
-                const thread_heap_data = @fieldParentPtr(ThreadHeapData, "heap", heap);
-                return &thread_heap_data.metadata;
+            const segment = Segment.ofPtr(ptr);
+            const heap = segment.heap;
+
+            if (config.safety_checks) {
+                if (!self.ownsHeap(heap)) return null;
             }
-        } else struct {};
+
+            return heap;
+        }
 
         pub fn allocator(self: *Self) std.mem.Allocator {
             return .{
@@ -156,16 +103,8 @@ pub fn Allocator(comptime config: Config) type {
             len: usize,
             log2_align: u8,
             ret_addr: usize,
-            comptime lock_held: bool,
         ) ?[*]align(constants.min_slot_alignment) u8 {
             log.debugVerbose("allocate: len={d} log2_align={d}", .{ len, log2_align });
-            if (config.memory_limit) |limit| {
-                assert.withMessage(@src(), self.stats.total_allocated_memory <= limit, "corrupt stats");
-                if (len + self.stats.total_allocated_memory > limit) {
-                    log.warn("allocation would exceed memory limit", .{});
-                    return null;
-                }
-            }
 
             const thread_id = std.Thread.getCurrentId();
 
@@ -173,68 +112,33 @@ pub fn Allocator(comptime config: Config) type {
             self.thread_heaps_lock.lockShared();
 
             var iter = self.thread_heaps.iterator(0);
-            while (iter.next()) |heap_data| {
-                if (heap_data.heap.thread_id == thread_id) {
+            while (iter.next()) |heap| {
+                if (heap.thread_id == thread_id) {
                     self.thread_heaps_lock.unlockShared();
-                    return self.allocInHeap(heap_data, len, log2_align, ret_addr, lock_held);
+                    return self.allocInHeap(heap, len, log2_align, ret_addr);
                 }
             } else {
                 self.thread_heaps_lock.unlockShared();
-                const heap_data = self.initHeapForThread() orelse return null;
-                return self.allocInHeap(heap_data, len, log2_align, ret_addr, lock_held);
+                const heap = self.initHeapForThread() orelse return null;
+                return self.allocInHeap(heap, len, log2_align, ret_addr);
             }
         }
 
         fn allocInHeap(
             self: *Self,
-            heap_data: *ThreadHeapData,
+            heap: *Heap,
             len: usize,
             log2_align: u8,
             ret_addr: usize,
-            comptime lock_held: bool,
         ) ?[*]align(constants.min_slot_alignment) u8 {
-            const heap = &heap_data.heap;
-            const metadata = &heap_data.metadata;
-
+            _ = self;
             assert.withMessage(
                 @src(),
                 heap.thread_id == std.Thread.getCurrentId(),
                 "tried to allocated from wrong thread",
             );
 
-            if (config.track_allocations) {
-                if (!lock_held) metadata.mutex.lock();
-                metadata.map.ensureUnusedCapacity(self.backing_allocator, 1) catch {
-                    log.debug("could not allocate metadata", .{});
-                    return null;
-                };
-            }
-            defer if (config.track_allocations) if (!lock_held) {
-                metadata.mutex.unlock();
-            };
-
             const allocation = heap.allocate(len, log2_align, ret_addr) orelse return null;
-
-            if (config.memory_limit) |limit| {
-                self.stats.total_allocated_memory += allocation.backing_size;
-                // TODO: this shouldn't be possible, heap.allocate() should respect
-                //       the limit, and this if statement can be replaced with an assert
-                if (self.stats.total_allocated_memory > limit) {
-                    _ = heap.deallocate(allocation.ptr[0..len], log2_align, ret_addr);
-                    self.stats.total_allocated_memory -= allocation.backing_size;
-                    return null;
-                }
-            }
-
-            if (config.track_allocations) {
-                metadata.map.putAssumeCapacity(
-                    @intFromPtr(allocation.ptr),
-                    .{
-                        .size = len,
-                        .is_huge = allocation.is_huge,
-                    },
-                );
-            }
 
             return allocation.ptr;
         }
@@ -244,7 +148,6 @@ pub fn Allocator(comptime config: Config) type {
             buf: []u8,
             log2_align: u8,
             ret_addr: usize,
-            comptime lock_held: bool,
         ) void {
             log.debugVerbose("deallocate: buf=({*}, {d}) log2_align={d}", .{ buf.ptr, buf.len, log2_align });
             // TODO: check this is valid on windows
@@ -253,18 +156,11 @@ pub fn Allocator(comptime config: Config) type {
                 self.thread_heaps_lock.lockShared();
                 defer self.thread_heaps_lock.unlockShared();
                 var heap_iter = self.thread_heaps.iterator(0);
-                while (heap_iter.next()) |heap_data| {
-                    heap_data.heap.huge_allocations.lock();
-                    defer heap_data.heap.huge_allocations.unlock();
-                    if (heap_data.heap.huge_allocations.containsRaw(buf.ptr)) {
-                        if (config.track_allocations) {
-                            if (!lock_held) heap_data.metadata.mutex.lock();
-                            defer if (!lock_held) heap_data.metadata.mutex.unlock();
-                            self.freeHugeFromHeap(&heap_data.heap, buf, log2_align, ret_addr, true);
-                            return;
-                        }
-
-                        self.freeHugeFromHeap(&heap_data.heap, buf, log2_align, ret_addr, true);
+                while (heap_iter.next()) |heap| {
+                    heap.huge_allocations.lock();
+                    defer heap.huge_allocations.unlock();
+                    if (heap.huge_allocations.containsRaw(buf.ptr)) {
+                        self.freeHugeFromHeap(heap, buf, log2_align, ret_addr, true);
                         return;
                     }
                 }
@@ -274,19 +170,9 @@ pub fn Allocator(comptime config: Config) type {
             const segment = Segment.ofPtr(buf.ptr);
             const heap = segment.heap;
 
-            if (config.track_allocations) {
-                const metadata = Self.heapMetadataUnsafe(heap);
-
-                if (!lock_held) metadata.mutex.lock();
-                defer if (!lock_held) metadata.mutex.unlock();
-                self.freeNonHugeFromHeap(heap, buf, log2_align, ret_addr);
-                return;
-            }
-
             self.freeNonHugeFromHeap(heap, buf, log2_align, ret_addr);
         }
 
-        /// if tracking allocations, caller must hold metadata lock of `heap`
         pub fn freeNonHugeFromHeap(self: *Self, heap: *Heap, buf: []u8, log2_align: u8, ret_addr: usize) void {
             log.debug("freeing non-huge allocation", .{});
             const segment = Segment.ofPtr(buf.ptr);
@@ -296,20 +182,9 @@ pub fn Allocator(comptime config: Config) type {
                 return;
             };
 
-            if (config.track_allocations) {
-                const metadata = Self.heapMetadataUnsafe(heap);
-                assert.withMessage(@src(), metadata.map.remove(@intFromPtr(buf.ptr)), "allocation metadata is missing");
-            }
-
-            const backing_size = heap.deallocateInSegment(segment, buf, log2_align, ret_addr);
-
-            if (config.memory_limit) |_| {
-                // this might race with concurrernt alloc
-                self.stats.total_allocated_memory -= backing_size;
-            }
+            heap.deallocateInSegment(segment, buf, log2_align, ret_addr);
         }
 
-        /// if tracking allocations, caller must hold metadata lock of `heap`
         pub fn freeHugeFromHeap(
             self: *Self,
             heap: *Heap,
@@ -324,20 +199,11 @@ pub fn Allocator(comptime config: Config) type {
             };
 
             if (!lock_held) heap.huge_allocations.lock();
-            const size = heap.deallocateHuge(buf, log2_align, ret_addr);
+            heap.deallocateHuge(buf, log2_align, ret_addr);
             if (!lock_held) heap.huge_allocations.unlock();
-
-            if (config.memory_limit) |_| {
-                self.stats.total_allocated_memory -= size;
-            }
-
-            if (config.track_allocations) {
-                const metadata = Self.heapMetadataUnsafe(heap);
-                assert.withMessage(@src(), metadata.map.remove(@intFromPtr(buf.ptr)), "huge allocation metadata is missing");
-            }
         }
 
-        pub fn usableSizeSegment(self: *Self, ptr: *anyopaque) ?usize {
+        pub fn usableSizeInSegment(self: *Self, ptr: *anyopaque) ?usize {
             const segment = Segment.ofPtr(ptr);
 
             if (config.safety_checks) if (!self.ownsHeap(segment.heap)) {
@@ -353,44 +219,32 @@ pub fn Allocator(comptime config: Config) type {
             return slot.len - offset;
         }
 
-        pub fn usableSize(self: *Self, ptr: *anyopaque, comptime lock_held: bool) ?usize {
+        pub fn usableSize(self: *Self, ptr: *anyopaque) ?usize {
             if (std.mem.isAligned(@intFromPtr(ptr), std.mem.page_size)) {
                 self.thread_heaps_lock.lockShared();
                 defer self.thread_heaps_lock.unlockShared();
                 var heap_iter = self.thread_heaps.iterator(0);
-                while (heap_iter.next()) |heap_data| {
-                    const size_opt = if (!lock_held)
-                        heap_data.heap.huge_allocations.get(ptr)
-                    else
-                        heap_data.heap.huge_allocations.getRaw(ptr);
-
-                    if (size_opt) |size| {
+                while (heap_iter.next()) |heap| {
+                    if (heap.huge_allocations.get(ptr)) |size| {
                         // WARNING: this depends on the implementation of std.heap.PageAllocator
                         // aligning allocated lengths to the page size
                         return std.mem.alignForward(usize, size, std.mem.page_size);
                     }
                 }
             }
-            return self.usableSizeSegment(ptr);
+            return self.usableSizeInSegment(ptr);
         }
 
         fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, ret_addr: usize) ?[*]u8 {
             assert.withMessage(@src(), std.mem.isAligned(@intFromPtr(ctx), @alignOf(@This())), "ctx is not aligned");
             const self: *@This() = @ptrCast(@alignCast(ctx));
 
-            return self.allocate(len, log2_align, ret_addr, false);
+            return self.allocate(len, log2_align, ret_addr);
         }
 
         fn resize(ctx: *anyopaque, buf: []u8, log2_align: u8, new_len: usize, ret_addr: usize) bool {
             assert.withMessage(@src(), std.mem.isAligned(@intFromPtr(ctx), @alignOf(@This())), "ctx is not aligned");
             const self: *@This() = @ptrCast(@alignCast(ctx));
-
-            if (config.memory_limit) |limit| {
-                const new_total = self.stats.total_allocated_memory - buf.len + new_len;
-                if (new_total > limit) {
-                    return false;
-                }
-            }
 
             const segment = Segment.ofPtr(buf.ptr);
             const owning_heap = segment.heap;
@@ -400,19 +254,14 @@ pub fn Allocator(comptime config: Config) type {
                 return false;
             };
 
-            const can_resize = owning_heap.canResizeInPlace(buf, log2_align, new_len, ret_addr);
-
-            // BUG: there is a bug for memory limiting here if `buf` is a huge allocation
-            //      that gets shrunk to a lower os page count (see std.heap.PageAllocator.resize)
-
-            return can_resize;
+            return owning_heap.canResizeInPlace(buf, log2_align, new_len, ret_addr);
         }
 
         fn free(ctx: *anyopaque, buf: []u8, log2_align: u8, ret_addr: usize) void {
             assert.withMessage(@src(), std.mem.isAligned(@intFromPtr(ctx), @alignOf(@This())), "ctx is not aligned");
             const self: *@This() = @ptrCast(@alignCast(ctx));
 
-            self.deallocate(buf, log2_align, ret_addr, false);
+            self.deallocate(buf, log2_align, ret_addr);
         }
     };
 }

--- a/src/libzimalloc.zig
+++ b/src/libzimalloc.zig
@@ -3,16 +3,6 @@ var allocator_instance = zimalloc.Allocator(.{
 }){};
 const allocator = allocator_instance.allocator();
 
-const AllocData = struct {
-    size: usize,
-};
-
-var metadata = std.AutoHashMap(usize, AllocData){
-    .unmanaged = .{},
-    .allocator = std.heap.page_allocator,
-    .ctx = undefined, // safe becuase AutoHashMap context type is zero sized
-};
-
 export fn malloc(len: usize) ?*anyopaque {
     log.debug("malloc {d}", .{len});
     return allocateBytes(len, 1, @returnAddress(), false, false, true);
@@ -44,7 +34,7 @@ export fn realloc(ptr_opt: ?*anyopaque, len: usize) ?*anyopaque {
             return null;
 
         const copy_len = @min(len, old_slice.len);
-        @memcpy(new_mem[0..copy_len], old_slice);
+        @memcpy(new_mem[0..copy_len], old_slice[0..copy_len]);
 
         allocator_instance.deallocate(old_slice, 0, @returnAddress(), false);
 

--- a/src/zimalloc.zig
+++ b/src/zimalloc.zig
@@ -3,7 +3,7 @@ pub const Config = @import("allocator.zig").Config;
 pub const Heap = @import("Heap.zig");
 
 test {
-    _ = Allocator(.{ .track_allocations = true, .memory_limit = 4096 });
+    _ = Allocator(.{});
     _ = @import("Heap.zig");
     _ = @import("list.zig");
     _ = @import("Page.zig");
@@ -14,23 +14,19 @@ test {
 }
 
 const configs = configs: {
-    const memory_limit = [_]?usize{ null, 165536 };
-    const track_allocations = [_]bool{ false, true };
     const safety_checks = [_]bool{ false, true };
 
-    const config_count = memory_limit.len * track_allocations.len * safety_checks.len;
+    const config_count = safety_checks.len;
     var result: [config_count]Config = undefined;
 
     var index = 0;
 
-    for (memory_limit) |limit| for (track_allocations) |track| for (safety_checks) |safety| {
+    for (safety_checks) |safety| {
         result[index] = Config{
-            .memory_limit = limit,
-            .track_allocations = track,
             .safety_checks = safety,
         };
         index += 1;
-    };
+    }
     break :configs result;
 };
 


### PR DESCRIPTION
This PR fixes some broken resize/realloc logic, enabling 4 more mimalloc-bench tests (rptest, lua, redis and rbstress). In addition the track_allocations and memory_limit options have been removed as this significantly simplifies the code - they can be added back in the future if desired.