### PR TITLE
fix: workaround spurious compiler dependency loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-           version: 0.11.0
+           version: master
 
       - name: Check formatting
         run: zig fmt --check .

--- a/src/Heap.zig
+++ b/src/Heap.zig
@@ -1,6 +1,8 @@
 thread_id: std.Thread.Id,
 pages: [size_class_count]Page.List,
-segments: ?Segment.Ptr,
+// TODO: Not using ?Segment.Ptr is a workaroiund for a compiler issue.
+//       Revert this when possible, see github.com/dweiller/zimalloc/issues/15
+segments: ?*align(constants.segment_alignment) Segment,
 huge_allocations: HugeAllocTable,
 
 const Heap = @This();


### PR DESCRIPTION
This is a workaround that fixes #12 and should be reverted when the upstream issue linked there is resolved.