### PR TITLE
feat!: replace freeNonHugeFromHeap with freeNonHuge

### DIFF
--- a/src/libzimalloc.zig
+++ b/src/libzimalloc.zig
@@ -45,12 +45,14 @@ export fn free(ptr_opt: ?*anyopaque) void {
             @memset(slice, undefined);
             allocator_instance.freeHuge(slice, 0, @returnAddress(), false);
         } else {
-            const heap = allocator_instance.getThreadHeap(ptr) orelse {
-                invalid("invalid free: {*} - no valid heap", .{ptr});
-                return;
-            };
+            if (build_options.panic_on_invalid) {
+                if (allocator_instance.getThreadHeap(ptr) == null) {
+                    invalid("invalid free: {*} - no valid heap", .{ptr});
+                    return;
+                }
+            }
 
-            allocator_instance.freeNonHugeFromHeap(heap, bytes_ptr, 0, @returnAddress());
+            allocator_instance.freeNonHuge(bytes_ptr, 0, @returnAddress());
         }
     }
 }


### PR DESCRIPTION
The `freeNonHugeFromHeap` API allowed passing a heap not corresponding to the pointer. The heap is easy to recover from a (valid) pointer, and all previous uses of `freeNonHugeFromHeap` did this, without needing the heap pointer otherwise. The new `freeNonHuge` API simplifies usage, preventing mismatched pointer/heap parameters being passed.