### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "::group::Install dependencies"
           sudo apt-get update
-          sudo apt-get install ghostscript ruby
+          sudo apt-get install ghostscript ruby libreadline-dev
           echo "::endgroup::"
           if command -v nproc > /dev/null; then
             procs=$(nproc)


### PR DESCRIPTION
The recent CI breakage is due to the move to the Ubuntu 24.04 images which don't have the readline header.